### PR TITLE
chore(operations): bring dashboard summary hook and release note to master

### DIFF
--- a/backend/app/api/operations.py
+++ b/backend/app/api/operations.py
@@ -12,6 +12,7 @@ from app.schemas.operations import (
     DispatchTickResponse,
     GenerateTasksRequest,
     GenerateTasksResponse,
+    OperationsDashboardSummaryRead,
     OperationsEventRead,
     OperationsStallsRead,
     OperationsTaskRead,
@@ -137,6 +138,28 @@ def get_stalls(_guard: None = Depends(_require_operations_access)) -> Operations
         longest_stall_seconds=longest_stall_seconds,
         average_stall_seconds=average_stall_seconds,
         tasks=[OperationsTaskRead.model_validate(task) for task in stalled],
+    )
+
+
+@router.get("/dashboard/summary", response_model=OperationsDashboardSummaryRead)
+def get_dashboard_summary(
+    _guard: None = Depends(_require_operations_access),
+) -> OperationsDashboardSummaryRead:
+    now = datetime.now(UTC)
+    worker_counts = _worker_status_counts()
+    stalled = RUNTIME_STORE.detect_stalled_tasks(threshold=STALL_THRESHOLD, now=now)
+    by_project, longest_stall_seconds, _average_stall_seconds = _stall_metrics(now=now)
+    return OperationsDashboardSummaryRead(
+        generated_at=now,
+        uptime_seconds=max(0, int((now - RUNTIME_STARTED_AT).total_seconds())),
+        queue_depth=RUNTIME_STORE.queue_size(),
+        queue_depth_by_priority=RUNTIME_STORE.queue_size_by_priority(),
+        workers_busy=int(worker_counts["busy"]),
+        workers_online=int(worker_counts["online"]),
+        worker_utilization_pct=float(worker_counts["utilization_pct"]),
+        stalled_count=len(stalled),
+        stalled_by_project=by_project,
+        longest_stall_seconds=longest_stall_seconds,
     )
 
 

--- a/backend/app/schemas/operations.py
+++ b/backend/app/schemas/operations.py
@@ -66,6 +66,19 @@ class OperationsStallsRead(BaseModel):
     tasks: list[OperationsTaskRead]
 
 
+class OperationsDashboardSummaryRead(BaseModel):
+    generated_at: datetime
+    uptime_seconds: int = Field(ge=0)
+    queue_depth: int = Field(ge=0)
+    queue_depth_by_priority: dict[str, int]
+    workers_busy: int = Field(ge=0)
+    workers_online: int = Field(ge=0)
+    worker_utilization_pct: float = Field(ge=0, le=100)
+    stalled_count: int = Field(ge=0)
+    stalled_by_project: dict[str, int]
+    longest_stall_seconds: int = Field(ge=0)
+
+
 class GenerateTasksRequest(BaseModel):
     goal: str = Field(min_length=3)
     project: str | None = None

--- a/backend/tests/test_operations_api.py
+++ b/backend/tests/test_operations_api.py
@@ -220,6 +220,18 @@ async def test_operations_uptime_and_stalls_include_aggregates(
             assert stalls_body["longest_stall_seconds"] == 1860
             assert stalls_body["average_stall_seconds"] == 1860.0
 
+            dashboard = await client.get(
+                "/api/v1/operations/dashboard/summary", headers=_auth_headers()
+            )
+            assert dashboard.status_code == 200
+            dashboard_body = dashboard.json()
+            assert dashboard_body["queue_depth"] == 1
+            assert dashboard_body["workers_busy"] == 1
+            assert dashboard_body["workers_online"] == 2
+            assert dashboard_body["worker_utilization_pct"] == 50.0
+            assert dashboard_body["stalled_count"] == 1
+            assert dashboard_body["stalled_by_project"] == {"alpha": 1}
+
             dispatch = await client.post(
                 "/api/v1/operations/dispatch/tick", headers=_auth_headers()
             )

--- a/docs/release/2026-03-operations-runtime-autopilot.md
+++ b/docs/release/2026-03-operations-runtime-autopilot.md
@@ -1,0 +1,44 @@
+# Release note: Operations runtime API + Mission Control skill (2026-03)
+
+## Summary
+This release adds an initial Operations runtime control surface and a dashboard summary hook for Mission Control Autopilot workflows.
+
+## What's included
+
+### 1) Operations API guardrails
+- All `/api/v1/operations/*` endpoints require admin auth.
+- Global feature flag: `operations_api_enabled`.
+- Write-route flag: `operations_runtime_write_enabled` for:
+  - `POST /api/v1/operations/goals/generate`
+  - `POST /api/v1/operations/dispatch/tick`
+
+### 2) Runtime observability endpoints
+- `GET /api/v1/operations/workers`
+- `GET /api/v1/operations/tasks`
+- `GET /api/v1/operations/events?limit=...`
+- `GET /api/v1/operations/uptime`
+- `GET /api/v1/operations/stalls`
+- `GET /api/v1/operations/dashboard/summary`
+
+`uptime` and `stalls` now expose worker utilization, queue depth by priority, stalled task ids, and project-level stall counts.
+
+### 3) Safe notifier boundary
+- `DiscordSummaryNotifier` now uses an adapter boundary (`SummaryDeliveryAdapter`).
+- Default adapter is logging-only (no external delivery side effects).
+- External delivery is enabled only when both are set:
+  - `operations_notifier_enabled=true`
+  - `operations_notifier_channel` is non-empty
+
+## How to use with the Mission Control skill
+Skill: `mission-control-autopilot`
+
+Typical operator loop:
+1. Enable API access in backend config (`operations_api_enabled=true`).
+2. Optionally enable write routes for controlled dispatch (`operations_runtime_write_enabled=true`).
+3. Observe runtime health via `/operations/uptime`, `/operations/stalls`, or `/operations/dashboard/summary`.
+4. Trigger dispatch ticks and goal-driven task generation only when write flag is enabled.
+5. Keep notifier in safe mode by default; wire an external adapter in a follow-up integration.
+
+## Backward compatibility
+- Default behavior remains safe-by-default: operations API and write paths can remain disabled by config.
+- No database migration required for this increment.

--- a/docs/release/README.md
+++ b/docs/release/README.md
@@ -1,5 +1,9 @@
 # Release checklist
 
+## Recent release notes
+
+- [2026-03: Operations runtime API + Mission Control skill](./2026-03-operations-runtime-autopilot.md)
+
 This is a lightweight, operator-friendly checklist for releasing Mission Control.
 
 > Goal: **no data loss** and **near-zero (ideally zero) user-visible downtime**.


### PR DESCRIPTION
Follow-up merge to bring already-merged stacked PR #7 contents onto master after #4/#6 merge order.\n\nIncludes:\n- dashboard summary endpoint wiring\n- operations API dashboard tests\n- release note for operations API + mission-control-autopilot skill\n\nValidation already executed in branch and CI green on #7.